### PR TITLE
feat: verification-code grant

### DIFF
--- a/src/grants/VerificationCodeGrantType.ts
+++ b/src/grants/VerificationCodeGrantType.ts
@@ -20,8 +20,8 @@ export abstract class VerificationCodeGrantType extends DefaultGrantType {
 
     const scope = this.getScope(request)
 
-    const { phoneNumber, code } = request.body
-    const user = await VerificationCodeGrantType.codeService.verify(phoneNumber, code)
+    const { key, code } = request.body
+    const user = await VerificationCodeGrantType.codeService.verify(key, code)
 
     if (user === false) {
       throw Error('Invalid code')

--- a/src/grants/VerificationCodeGrantType.ts
+++ b/src/grants/VerificationCodeGrantType.ts
@@ -1,0 +1,32 @@
+import OAuth2Server, { InvalidArgumentError } from '@node-oauth/oauth2-server'
+import { VerificationCodeService } from '../types'
+import { DefaultGrantType } from './DefaultGrantType'
+
+export abstract class VerificationCodeGrantType extends DefaultGrantType {
+  private static codeService: VerificationCodeService
+
+  public static configure (codeService: VerificationCodeService): void {
+    this.codeService = codeService
+  }
+
+  async handle (request: OAuth2Server.Request, client: OAuth2Server.Client): Promise<OAuth2Server.Token | OAuth2Server.Falsey> {
+    if (request == null) {
+      throw new InvalidArgumentError('Missing parameter: `request`')
+    }
+
+    if (client == null) {
+      throw new InvalidArgumentError('Missing parameter: `client`')
+    }
+
+    const scope = this.getScope(request)
+
+    const { phoneNumber, code } = request.body
+    const user = await VerificationCodeGrantType.codeService.verify(phoneNumber, code)
+
+    if (user === false) {
+      throw Error('Invalid code')
+    }
+
+    return await this.saveToken(user, client, scope)
+  }
+}

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -7,6 +7,7 @@ import { BurgerProfielGrantType } from './grants/BurgerProfielGrantType'
 import { WoningpasGrantType } from './grants/WoningpasGrantType'
 import { GoogleGrantType } from './grants/GoogleGrantType'
 import { AppleGrantType } from './grants/AppleGrantType'
+import { VerificationCodeGrantType } from './grants/VerificationCodeGrantType'
 
 export function createOAuth2 (options: OAuth2ServerOptions): OAuth2Server {
   const codeModel = generateAuthorizationCodeModel(options.services.codeService)
@@ -160,6 +161,22 @@ export function createOAuth2 (options: OAuth2ServerOptions): OAuth2Server {
     )
 
     serverOptions.extendedGrantTypes.apple = AppleGrantType
+  }
+
+  if (options.integrations?.verificationCode != null) {
+    if (options.services.verificationCodeService == null) {
+      throw new Error('Verification Code service must be implemented')
+    }
+
+    if (options.services.verificationCodeService?.verify == null) {
+      throw new Error('Verification Code service must implement verify for verificationCode integration')
+    }
+
+    VerificationCodeGrantType.configure(
+      options.services.verificationCodeService
+    )
+
+    serverOptions.extendedGrantTypes.verificationCode = VerificationCodeGrantType
   }
 
   return new OAuth2Server(serverOptions)

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export interface CodeService {
 }
 
 export interface VerificationCodeService {
-  verify: (phoneNumber: string, code: string) => Promise<User | false>
+  verify: (key: string, code: number) => Promise<User | false>
 }
 
 export interface PKCEService {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,10 @@ export interface CodeService {
   revokeAuthorizationCode: (code: AuthorizationCode) => Promise<boolean>
 }
 
+export interface VerificationCodeService {
+  verify: (phoneNumber: string, code: string) => Promise<User | false>
+}
+
 export interface PKCEService {
   find: (state: string) => Promise<PKCEType>
   create: (pkce: PKCEType) => Promise<PKCEType>
@@ -77,6 +81,7 @@ export interface OAuth2ServerOptions {
     tokenService: TokenService
     pkceService?: PKCEService
     codeService?: CodeService
+    verificationCodeService?: VerificationCodeService
   }
   integrations?: {
     ad?: AzureADConfig
@@ -85,6 +90,7 @@ export interface OAuth2ServerOptions {
     burgerProfiel?: IBurgerProfielConfig
     google?: boolean
     apple?: boolean
+    verificationCode?: boolean
   }
   extendedGrantTypes?: Record<string, typeof AbstractGrantType>
 }


### PR DESCRIPTION
add functionality to verify on a simple verification code

i expect that the verify function will expect a `key` which the `code` could be validated against, for example a phone number.